### PR TITLE
Fix toast listener cleanup

### DIFF
--- a/app/components/ui/use-toast.ts
+++ b/app/components/ui/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/app/hooks/use-toast.ts
+++ b/app/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix `useEffect` dependencies in toast hook to avoid stacking listeners

## Testing
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6873252b7dbc832682c9931edde25628