### PR TITLE
Improve video URL validation

### DIFF
--- a/app/lib/video-utils.ts
+++ b/app/lib/video-utils.ts
@@ -38,8 +38,10 @@ export function generateVideoId(): string {
 export function validateVideoURL(url: string): boolean {
   try {
     const urlObj = new URL(url);
-    const pathname = urlObj.pathname.toLowerCase();
-    return SUPPORTED_FORMATS.some(format => pathname.endsWith(`.${format}`));
+    const pathAndQuery = `${urlObj.pathname}${urlObj.search}`.toLowerCase();
+    return SUPPORTED_FORMATS.some(format =>
+      pathAndQuery.includes(`.${format}`)
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- support query strings in video URLs when validating

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68732bd9b354832691bcdd23aed18c3e